### PR TITLE
Adds support for query timeouts

### DIFF
--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -32,7 +32,7 @@ defmodule Sqlitex.Query do
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql, opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),
-         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
+         {:ok, res} <- Statement.fetch_all(stmt, Keyword.get(opts, :db_timeout, 5_000), Keyword.get(opts, :into, [])),
     do: {:ok, res}
   end
 
@@ -77,7 +77,7 @@ defmodule Sqlitex.Query do
   def query_rows(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql, opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),
-         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
+         {:ok, rows} <- Statement.fetch_all(stmt, Keyword.get(opts, :db_timeout, 5_000), :raw_list),
     do: {:ok, %{rows: rows, columns: stmt.column_names, types: stmt.column_types}}
   end
 

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -178,7 +178,7 @@ defmodule Sqlitex.Server do
 
     with {%Cache{} = new_cache, stmt} <- Cache.prepare(stmt_cache, sql, db_opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), db_opts),
-         {:ok, rows} <- Statement.fetch_all(stmt, Keyword.get(opts, :into, [])),
+         {:ok, rows} <- Statement.fetch_all(stmt, Keyword.get(opts, :db_timeout, 5_000), Keyword.get(opts, :into, [])),
     do: {:ok, rows, new_cache}
   end
 
@@ -187,7 +187,7 @@ defmodule Sqlitex.Server do
 
     with {%Cache{} = new_cache, stmt} <- Cache.prepare(stmt_cache, sql, db_opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), db_opts),
-         {:ok, rows} <- Statement.fetch_all(stmt, :raw_list),
+         {:ok, rows} <- Statement.fetch_all(stmt, Keyword.get(opts, :db_timeout, 5_000), :raw_list),
     do: {:ok,
          %{rows: rows, columns: stmt.column_names, types: stmt.column_types},
          new_cache}

--- a/lib/sqlitex/statement.ex
+++ b/lib/sqlitex/statement.ex
@@ -74,6 +74,7 @@ defmodule Sqlitex.Statement do
             column_types: []
 
   @chunk_size 5000
+  @default_timeout 5000
 
   alias Sqlitex.Config
 
@@ -180,7 +181,8 @@ defmodule Sqlitex.Statement do
   * `{:ok, results}`
   * `{:error, error}`
   """
-  def fetch_all(statement, timeout, into \\ []) do
+
+  def fetch_all(statement, timeout \\ @default_timeout, into \\ []) do
     case raw_fetch_all(statement, timeout) do
       {:error, _} = other -> other
       raw_data ->
@@ -200,7 +202,7 @@ defmodule Sqlitex.Statement do
 
   Returns the results otherwise.
   """
-  def fetch_all!(statement, timeout, into \\ []) do
+  def fetch_all!(statement, timeout \\ @default_timeout, into \\ []) do
     case fetch_all(statement, timeout, into) do
       {:ok, results} -> results
       {:error, reason} -> raise Sqlitex.Statement.FetchAllError, reason: reason

--- a/test/statement_test.exs
+++ b/test/statement_test.exs
@@ -7,7 +7,7 @@ defmodule StatementTest do
 
     result = db
               |> Sqlitex.Statement.prepare!("PRAGMA user_version;")
-              |> Sqlitex.Statement.fetch_all!
+              |> Sqlitex.Statement.fetch_all!(1_000)
 
     assert result == [[user_version: 0]]
   end
@@ -20,7 +20,7 @@ defmodule StatementTest do
     stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
                                           <> ";--RETURNING ON INSERT x,id")
 
-    rows = Sqlitex.Statement.fetch_all!(stmt)
+    rows = Sqlitex.Statement.fetch_all!(stmt, 1_000)
     assert rows == [[id: 1]]
   end
 
@@ -32,7 +32,7 @@ defmodule StatementTest do
     stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES (?1) "
                                           <> ";--RETURNING ON INSERT x,id")
 
-    rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+    rows = Sqlitex.Statement.fetch_all!(stmt, 1_000, :raw_list)
     assert rows == [[1]]
   end
 
@@ -44,7 +44,7 @@ defmodule StatementTest do
     stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
                                           <> ";--RETURNING ON INSERT x,id")
 
-    rows = Sqlitex.Statement.fetch_all!(stmt)
+    rows = Sqlitex.Statement.fetch_all!(stmt, 1_000)
     assert rows == [[id: 1], [id: 2], [id: 3]]
   end
 
@@ -56,7 +56,7 @@ defmodule StatementTest do
     stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x'),('y'),('z') "
                                           <> ";--RETURNING ON INSERT x,id")
 
-    rows = Sqlitex.Statement.fetch_all!(stmt, :raw_list)
+    rows = Sqlitex.Statement.fetch_all!(stmt, 1_000, :raw_list)
     assert rows == [[1], [2], [3]]
   end
 
@@ -71,7 +71,7 @@ defmodule StatementTest do
     stmt = Sqlitex.Statement.prepare!(db, "INSERT INTO x(str) VALUES ('x') "
                                           <> ";--RETURNING ON INSERT x,id")
 
-    result = Sqlitex.Statement.fetch_all(stmt, :raw_list)
+    result = Sqlitex.Statement.fetch_all(stmt, 1_000, :raw_list)
     assert result == {:error, {:constraint, 'UNIQUE constraint failed: x.str'}}
   end
 end


### PR DESCRIPTION
I need the ability to specify per-query timeouts. I've been using my own fork of sqlitex while waiting for the esqlite changes to get merged.

Now that they're merged, it would be nice to get query timeout support into this project so I can use the official releases again.