### PR TITLE
run tests for multiple elixir versions and add dialyzer checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix do deps.get, compile
-      - run: mix format --check-formatted
       - run: mix dialyzer --halt-exit-status
       - run: mix credo --strict
       - run: mix coveralls.circle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,36 @@ jobs:
           - "_build"
           - "~/.mix"
       - run: mix test
+
+  lint:
+    parameters:
+      version:
+        description: Elixir Version
+        type: string
+        default: *default_version
+    parallelism: 1
+    docker:
+      - image: elixir:<< parameters.version >>
+    working_directory: ~/app
+    steps:
+      - checkout  # check out source code to working directory
+      - restore_cache:
+          keys:
+            - lint-<<parameters.version>>-{{ checksum "mix.lock" }}
+      - run: mix local.hex --force
+      - run: mix local.rebar --force
+      - run: mix do deps.get, compile
+      - run: mix format --check-formatted
+      - run: mix dialyzer --halt-exit-status
+      - run: mix credo --strict
+      - run: mix coveralls.circle
+      - save_cache:
+          key: lint-<<parameters.version>>-{{ checksum "mix.lock" }}
+          paths:
+          - "deps"
+          - "_build"
+          - "~/.mix"
+
 workflows:
   version: 2.1
   testing_all_versions:
@@ -48,3 +78,5 @@ workflows:
       - build:
           name: "Test Elixir 1.4.5"
           version: 1.4.5
+      - lint:
+          name: "Check Formatting, Types and Coverage"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,50 @@
-version: 2.0
+version: 2.1
+
+default_version: &default_version 1.8.1
+
 jobs:
   build:
+    parameters:
+      version:
+        description: Elixir Version
+        type: string
+        default: *default_version
+    parallelism: 1
     docker:
-      - image: circleci/elixir:1.8.1
-    environment:
-      MIX_ENV: test
+      - image: elixir:<< parameters.version >>
+    working_directory: ~/app
+
     steps:
       - checkout
       - restore_cache:
           keys:
-            - v2-dependency-cache-{{ checksum "mix.lock" }}
+            - build-<<parameters.version>>
       - run: mix local.hex --force
       - run: mix local.rebar --force
-      - run: mix deps.get
-      - run: mix deps.compile
-      - run: mix compile
-      - run: mix credo --strict
-      - run: mix coveralls.circle
+      - run: mix do deps.get, compile
       - save_cache:
-          key: v2-dependency-cache-{{ checksum "mix.lock" }}
+          key: build-<<parameters.version>>
           paths:
-            - _build
-            - deps
+          - "deps"
+          - "_build"
+          - "~/.mix"
+      - run: mix test
+workflows:
+  version: 2.1
+  testing_all_versions:
+    jobs:
+      - build:
+          name: "Test Elixir 1.8.1"
+          version: 1.8.1
+      - build:
+          name: "Test Elixir 1.7.4"
+          version: 1.7.4
+      - build:
+          name: "Test Elixir 1.6.6"
+          version: 1.6.6
+      - build:
+          name: "Test Elixir 1.5.3"
+          version: 1.5.3
+      - build:
+          name: "Test Elixir 1.4.5"
+          version: 1.4.5

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Sqlitex.Mixfile do
       {:esqlite, "~> 0.4"},
       {:decimal, "~> 1.7"},
       {:credo, "~> 0.10", only: [:dev, :test]},
-      {:dialyxir, "~> 1.0.0-rc.4", only: :dev, runtime: false},
+      {:dialyxir, "~> 1.0.0-rc.4", only: [:dev, :test], runtime: false},
       {:excoveralls, "~> 0.10", only: :test},
       {:ex_doc, "~> 0.20", only: :docs, runtime: false},
       {:excheck, "~> 0.6", only: :test},


### PR DESCRIPTION
This is an attempt to improve our CI checks. In our `mix.exs` file we support elixir `~> 1.4`, but we currently only run our CI checks against `1.8.1`. This would change out Circle config to build and run tests on each of `1.4.5`, `1.5.3`, `1.6.6`, `1.7.4` and `1.8.1` (the latest patch for each minor version since 1.4) and also run a single job that runs credo checks, dialyzer checks, formatting checks and code coverage checks.