### PR TITLE
Fix typespecs that refer to list of keywords but are instead coded as an empty list containing another empty list

### DIFF
--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -109,12 +109,12 @@ defmodule Sqlitex do
   end
 
   @doc "A shortcut to `Sqlitex.Query.query/3`"
-  @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
-  @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [[]]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [keyword]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [keyword]} | {:error, term()}
   def query(db, sql, opts \\ []), do: Sqlitex.Query.query(db, sql, opts)
 
   @doc "A shortcut to `Sqlitex.Query.query!/3`"
-  @spec query!(Sqlitex.connection, String.t | charlist) :: [[]]
+  @spec query!(Sqlitex.connection, String.t | charlist) :: [keyword]
   @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t, db_timeout: integer()]) :: [Enum.t]
   def query!(db, sql, opts \\ []), do: Sqlitex.Query.query!(db, sql, opts)
 

--- a/lib/sqlitex/query.ex
+++ b/lib/sqlitex/query.ex
@@ -36,8 +36,8 @@ defmodule Sqlitex.Query do
     @type charlist :: char_list
   end
 
-  @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [[]]} | {:error, term()}
-  @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [[]]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist) :: {:ok, [keyword]} | {:error, term()}
+  @spec query(Sqlitex.connection, String.t | charlist, [{atom, term}]) :: {:ok, [keyword]} | {:error, term()}
   def query(db, sql, opts \\ []) do
     with {:ok, stmt} <- Statement.prepare(db, sql, opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),
@@ -50,7 +50,7 @@ defmodule Sqlitex.Query do
 
   Returns the results otherwise.
   """
-  @spec query!(Sqlitex.connection, String.t | charlist) :: [[]]
+  @spec query!(Sqlitex.connection, String.t | charlist) :: [keyword]
   @spec query!(Sqlitex.connection, String.t | charlist, [bind: [], into: Enum.t, db_timeout: integer()]) :: [Enum.t]
   def query!(db, sql, opts \\ []) do
     case query(db, sql, opts) do


### PR DESCRIPTION
When doing something as simple as:

```elixir
case Sqlitex.query!(conn, "pragma #{clause};") do
  [[{^key, value}]] ->
    single_value(key, value)

  values when is_list(values) ->
    multiple_values(key, values)
end
```

...I get this Dialyzer error:

```plain
lib/yourapp/yourapp.ex:100:pattern_match
The pattern can never match the type.

Pattern:
[[{_, _value}]]

Type:
[[]]
```

Upon inspecting Sqlitex's code, I noticed that the `query` / `query!` functions have two specs each (to cover for the default and non-default parameters) but where a list of zero or more keyword lists is expected to be returned, the spec says the function should return `[[]]`.

This PR modifies the `[[]]` specs to the more accurate `[keyword]`.