### PR TITLE
with_transaction #2

### DIFF
--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -189,7 +189,7 @@ defmodule Sqlitex do
     try do
       {:ok, apply(fun, args)}
     rescue
-      error -> {:error, {error, __STACKTRACE__}}
+      error -> {:rescued, error, __STACKTRACE__}
     end
   end
 end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -189,7 +189,7 @@ defmodule Sqlitex do
     try do
       {:ok, apply(fun, args)}
     rescue
-      error -> {:error, error}
+      error -> {:error, {error, __STACKTRACE__}}
     end
   end
 end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -153,7 +153,7 @@ defmodule Sqlitex do
   @spec with_transaction(Sqlitex.connection, (Sqlitex.connection -> any()), Keyword.t) :: any
   def with_transaction(db, fun, opts \\ []) do
     with :ok <- exec(db, "begin", opts),
-      {:ok, result} <- apply_rescueing(fun, [db]),
+      {:ok, result} <- apply_rescuing(fun, [db]),
       :ok <- exec(db, "commit", opts)
     do
       {:ok, result}
@@ -172,7 +172,7 @@ defmodule Sqlitex do
 
  ## Private Helpers
 
- defp apply_rescueing(fun, args) do
+ defp apply_rescuing(fun, args) do
     try do
       {:ok, apply(fun, args)}
     rescue

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -150,6 +150,19 @@ defmodule Sqlitex do
     exec(db, stmt, call_opts)
   end
 
+  @doc """
+    Runs `fun` inside a transaction. If `fun` returns without raising an exception,
+    the transaction will be commited via `commit`. Otherwise, `rollback` will be called.
+
+    ## Examples
+      iex> {:ok, db} = Sqlitex.open(":memory:")
+      iex> Sqlitex.with_transaction(db, fn(db) ->
+      ...>   Sqlitex.exec(db, "create table foo(id integer)")
+      ...>   Sqlitex.exec(db, "insert into foo (id) values(42)")
+      ...> end)
+      iex> Sqlitex.query(db, "select * from foo")
+      {:ok, [[{:id, 42}]]}
+  """
   @spec with_transaction(Sqlitex.connection, (Sqlitex.connection -> any()), Keyword.t) :: any
   def with_transaction(db, fun, opts \\ []) do
     with :ok <- exec(db, "begin", opts),

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -45,10 +45,10 @@ defmodule Sqlitex do
   Sqlitex.query(db, "select * from mytable", db_chunk_size: 500)
   ```
   in this case all rows will be passed from native sqlite OS thread to the erlang process in two passes.
-  Each pass will contain 500 rows.  
+  Each pass will contain 500 rows.
   This parameter decrease overhead of transmitting rows from native OS sqlite thread to the erlang process by
-  chunking list of result rows.  
-  Please, decrease this value if rows are heavy. Default value is 5000.  
+  chunking list of result rows.
+  Please, decrease this value if rows are heavy. Default value is 5000.
   If you in doubt what to do with this parameter, please, do nothing. Default value is ok.
   ```
   config :sqlitex, db_chunk_size: 500 # if most of the database rows are heavy
@@ -172,7 +172,7 @@ defmodule Sqlitex do
       {:ok, result}
     else
       err ->
-        :ok = exec(db, "rollback")
+        :ok = exec(db, "rollback", opts)
         err
     end
   end

--- a/lib/sqlitex.ex
+++ b/lib/sqlitex.ex
@@ -150,9 +150,33 @@ defmodule Sqlitex do
     exec(db, stmt, call_opts)
   end
 
+  @spec with_transaction(Sqlitex.connection, (Sqlitex.connection -> any()), Keyword.t) :: any
+  def with_transaction(db, fun, opts \\ []) do
+    with :ok <- exec(db, "begin", opts),
+      {:ok, result} <- apply_rescueing(fun, [db]),
+      :ok <- exec(db, "commit", opts)
+    do
+      {:ok, result}
+    else
+      err ->
+        :ok = exec(db, "rollback")
+        err
+    end
+  end
+
  if Version.compare(System.version, "1.3.0") == :lt do
    defp string_to_charlist(string), do: String.to_char_list(string)
  else
    defp string_to_charlist(string), do: String.to_charlist(string)
  end
+
+ ## Private Helpers
+
+ defp apply_rescueing(fun, args) do
+    try do
+      {:ok, apply(fun, args)}
+    rescue
+      error -> {:error, error}
+    end
+  end
 end

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -215,7 +215,13 @@ defmodule Sqlitex.Server do
       {:ok, [[{:id, 42}]]}
   """
   def with_transaction(pid, fun, opts \\ []) do
-    call(pid, {:with_transaction, fun}, opts)
+    case call(pid, {:with_transaction, fun}, opts) do
+      {:rescued, error, trace} ->
+        Kernel.reraise(error, trace)
+
+      other ->
+        other
+    end
   end
 
   ## Helpers

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -239,6 +239,4 @@ defmodule Sqlitex.Server do
     with {%Cache{} = new_cache, stmt} <- Cache.prepare(stmt_cache, sql, opts),
     do: {:ok, %{columns: stmt.column_names, types: stmt.column_types}, new_cache}
   end
-
-  defp timeout(kwopts), do: Keyword.get(kwopts, :timeout, 5000)
 end

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -119,9 +119,9 @@ defmodule Sqlitex.Server do
     {:reply, result, {db, stmt_cache, config}}
   end
 
-  def handle_call({:with_transaction, fun}, _from, {db, stmt_cache, timeout}) do
+  def handle_call({:with_transaction, fun}, _from, {db, stmt_cache, config}) do
     result = Sqlitex.with_transaction(db, fun)
-    {:reply, result, {db, stmt_cache, timeout}}
+    {:reply, result, {db, stmt_cache, config}}
   end
 
   def handle_cast(:stop, {db, stmt_cache, config}) do
@@ -214,7 +214,7 @@ defmodule Sqlitex.Server do
   """
   @spec with_transaction(pid(), (Sqlitex.connection -> any()), Keyword.t) :: any
   def with_transaction(pid, fun, opts \\ []) do
-    GenServer.call(pid, {:with_transaction, fun}, timeout(opts))
+    GenServer.call(pid, {:with_transaction, fun}, Config.call_timeout(opts))
   end
 
   ## Helpers

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -120,16 +120,8 @@ defmodule Sqlitex.Server do
   end
 
   def handle_call({:with_transaction, fun}, _from, {db, stmt_cache, timeout}) do
-    with :ok <- Sqlitex.exec(db, "begin"),
-          {:ok, result} <- apply_rescueing(fun, [db]),
-          :ok <- Sqlitex.exec(db, "commit")
-    do
-      {:reply, result, {db, stmt_cache, timeout}}
-    else
-      err ->
-        :ok = Sqlitex.exec(db, "rollback")
-        {:reply, err, {db, stmt_cache, timeout}}
-    end
+    result = Sqlitex.with_transaction(db, fun)
+    {:reply, result, {db, stmt_cache, timeout}}
   end
 
   def handle_cast(:stop, {db, stmt_cache, config}) do
@@ -209,20 +201,13 @@ defmodule Sqlitex.Server do
     Runs `fun` inside a transaction. If `fun` returns without raising an exception,
     the transaction will be commited via `commit`. Otherwise, `rollback` will be called.
 
-    Statements are executed in the server process and are guaranteed to get executed
-    sequentially without any interleaved statements from other processes.
-
-    It's important to use `Sqlitex.exec`, `Sqlitex.query`, ... instead of
-    `Sqlitex.Server.exec`, ... inside the transaction as the `db` arg to `fun` is of
-    type `Sqlitex.connection`.
-
     ## Examples
-      iex> {:ok, s} = Sqlitex.Server.start_link(':memory:')
-      iex> Sqlitex.Server.with_transaction(s, fn(db) ->
+      iex> {:ok, db} = Sqlitex.open(":memory:")
+      iex> Sqlitex.with_transaction(db, fn(db) ->
       ...>   Sqlitex.exec(db, "create table foo(id integer)")
       ...>   Sqlitex.exec(db, "insert into foo (id) values(42)")
       ...> end)
-      iex> Sqlitex.Server.query(s, "select * from foo")
+      iex> Sqlitex.query(db, "select * from foo")
       {:ok, [[{:id, 42}]]}
   """
   @spec with_transaction(pid(), (Sqlitex.connection -> any()), Keyword.t) :: any
@@ -254,12 +239,4 @@ defmodule Sqlitex.Server do
   end
 
   defp timeout(kwopts), do: Keyword.get(kwopts, :timeout, 5000)
-
-  defp apply_rescueing(fun, args) do
-    try do
-      {:ok, apply(fun, args)}
-    rescue
-      error -> {:error, error}
-    end
-  end
 end

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -200,13 +200,16 @@ defmodule Sqlitex.Server do
     Runs `fun` inside a transaction. If `fun` returns without raising an exception,
     the transaction will be commited via `commit`. Otherwise, `rollback` will be called.
 
+    Be careful if `fun` might take a long time to run. The function is executed in the
+    context of the server and therefore blocks other requests until it's finished.
+
     ## Examples
-      iex> {:ok, db} = Sqlitex.open(":memory:")
-      iex> Sqlitex.with_transaction(db, fn(db) ->
+      iex> {:ok, server} = Sqlitex.Server.start_link(":memory:")
+      iex> Sqlitex.Server.with_transaction(server, fn(db) ->
       ...>   Sqlitex.exec(db, "create table foo(id integer)")
       ...>   Sqlitex.exec(db, "insert into foo (id) values(42)")
       ...> end)
-      iex> Sqlitex.query(db, "select * from foo")
+      iex> Sqlitex.Server.query(server, "select * from foo")
       {:ok, [[{:id, 42}]]}
   """
   @spec with_transaction(pid(), (Sqlitex.connection -> any()), Keyword.t) :: any

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -212,7 +212,7 @@ defmodule Sqlitex.Server do
       iex> Sqlitex.Server.query(server, "select * from foo")
       {:ok, [[{:id, 42}]]}
   """
-  @spec with_transaction(pid(), (Sqlitex.connection -> any()), Keyword.t) :: any
+  @spec with_transaction(pid() | atom(), (Sqlitex.connection -> any()), Keyword.t) :: any
   def with_transaction(pid, fun, opts \\ []) do
     GenServer.call(pid, {:with_transaction, fun}, Config.call_timeout(opts))
   end

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -247,8 +247,6 @@ defmodule Sqlitex.Server do
     end
   end
 
-
-
   defp query_impl(sql, stmt_cache, opts) do
     with {%Cache{} = new_cache, stmt} <- Cache.prepare(stmt_cache, sql, opts),
          {:ok, stmt} <- Statement.bind_values(stmt, Keyword.get(opts, :bind, []), opts),

--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -196,7 +196,6 @@ defmodule Sqlitex.Server do
     GenServer.cast(pid, :stop)
   end
 
-
   @doc """
     Runs `fun` inside a transaction. If `fun` returns without raising an exception,
     the transaction will be commited via `commit`. Otherwise, `rollback` will be called.

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -9,7 +9,7 @@ defmodule Sqlitex.ServerTest do
     :ok = Server.exec(server, "create table foo(id integer)")
 
     Server.with_transaction(server, fn db ->
-      :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+      :ok = Server.exec(db, "insert into foo (id) values (42)")
     end)
 
     assert Server.query(server, "select * from foo") == {:ok, [[{:id, 42}]]}
@@ -23,7 +23,7 @@ defmodule Sqlitex.ServerTest do
 
     try do
       Server.with_transaction(server, fn db ->
-        :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+        :ok = Server.exec(db, "insert into foo (id) values (42)")
         raise "Error to roll back transaction"
       end)
     rescue

--- a/test/server_test.exs
+++ b/test/server_test.exs
@@ -1,4 +1,35 @@
 defmodule Sqlitex.ServerTest do
   use ExUnit.Case
   doctest Sqlitex.Server
+
+  test "with_transaction commit" do
+    alias Sqlitex.Server
+
+    {:ok, server} = Server.start_link(':memory:')
+    :ok = Server.exec(server, "create table foo(id integer)")
+
+    Server.with_transaction(server, fn db ->
+      :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+    end)
+
+    assert Server.query(server, "select * from foo") == {:ok, [[{:id, 42}]]}
+  end
+
+  test "with_transaction rollback" do
+    alias Sqlitex.Server
+
+    {:ok, server} = Server.start_link(':memory:')
+    :ok = Server.exec(server, "create table foo(id integer)")
+
+    try do
+      Server.with_transaction(server, fn db ->
+        :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+        raise "Error to roll back transaction"
+      end)
+    rescue
+      _ -> nil
+    end
+
+    assert Server.query(server, "select * from foo") == {:ok, []}
+  end
 end

--- a/test/sqlitex_test.exs
+++ b/test/sqlitex_test.exs
@@ -250,4 +250,31 @@ defmodule Sqlitex.Test do
     assert row[:b] == nil
     assert row[:c] == nil
   end
+
+  test "with_transaction commit" do
+    {:ok, db} = Sqlitex.open(":memory:")
+    :ok = Sqlitex.exec(db, "create table foo(id integer)")
+
+    Sqlitex.with_transaction(db, fn db ->
+      :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+    end)
+
+    assert Sqlitex.query(db, "select * from foo") == {:ok, [[{:id, 42}]]}
+  end
+
+  test "with_transaction rollback" do
+    {:ok, db} = Sqlitex.open(':memory:')
+    :ok = Sqlitex.exec(db, "create table foo(id integer)")
+
+    try do
+      Sqlitex.with_transaction(db, fn db ->
+        :ok = Sqlitex.exec(db, "insert into foo (id) values (42)")
+        raise "Error to roll back transaction"
+      end)
+    rescue
+      _ -> nil
+    end
+
+    assert Sqlitex.query(db, "select * from foo") == {:ok, []}
+  end
 end


### PR DESCRIPTION
On the original pull request there is unfortunately not much traction. But here is the grown version that I'm using in the mean time since. It has a couple of improvements on top of the initial with_transaction pull request.

- Server.with_transaction() becomes reentrancy safe. Instead of passing a pure Sqlitex db instance, it is passing it's own pid as parameters, and it's safe to call all Server.* methods on it without getting stuck in a GenServer self-call

- This allows **faster** query() within with_transaction() calls because the StatementCache of the Sqlitex.Server instance is now used.  

```
BEFORE
      iex> Sqlitex.Server.with_transaction(server, fn(db) ->
      ...>   Sqlitex.exec(db, "create table foo(id integer)")
      ...>   Sqlitex.exec(db, "insert into foo (id) values(42)")
      ...> end)
NOW
      iex> Sqlitex.Server.with_transaction(server, fn(pid) ->
      ...>   Sqlitex.Server.query(pid, "create table foo(id integer)")
      ...>   Sqlitex.Server.query(pid, "insert into foo (id) values(42)")
      ...> end)
```

- This also allows calling Server.with_transaction() within a transaction -- double wrapping of the statement is avoided. So you can write small functions that execute transactions but reuse them in other transaction creating functions.
```
      iex> Sqlitex.Server.with_transaction(server, fn(pid) ->
      ...>   Sqlitex.Server.with_transaction(pid, fn(pid2) ->
      ...>     Sqlitex.Server.query(pid2, "create table foo(id integer)")
      ...>     Sqlitex.Server.query(pid2, "insert into foo (id) values(42)")
      ...>   end)
      ...> end)
```

- Errors in SQL statements within the Servers with_transaction are rescued as before but then **rethrown** in the context of the caller for easier debugging and locating of errors.
