### PR TITLE
Fixed endless loop when process not found

### DIFF
--- a/lib/sqlitex/server.ex
+++ b/lib/sqlitex/server.ex
@@ -225,6 +225,10 @@ defmodule Sqlitex.Server do
   end
 
   ## Helpers
+  defp call(nil, _command, _opts) do
+    throw :no_such_process
+  end
+
   defp call(atom, command, opts) when is_atom(atom) do
     call(Process.whereis(atom), command, opts)
   end


### PR DESCRIPTION
The helper that takes an atom converts that into a pid, but in the case that a `Process.whereis(bla)` returns `nil` this unfortunately did lead to an endless loop. I've added a `nil` case now that fixes this loop.